### PR TITLE
Fix invalid header value, atualiza o node e npm além de usar npm ci

### DIFF
--- a/.github/workflows/deployPostmanCollection.yml
+++ b/.github/workflows/deployPostmanCollection.yml
@@ -19,9 +19,6 @@ jobs:
           node-version: 16.x
           cache: 'npm'
 
-      - name: Install npm 8.5.0
-        run: npm install -g npm@8.5.0
-
       - name: Npm Install
         run: npm ci
 

--- a/.github/workflows/deployPostmanCollection.yml
+++ b/.github/workflows/deployPostmanCollection.yml
@@ -25,5 +25,7 @@ jobs:
       - name: Npm Install
         run: npm ci
 
-      - name: Build
+      - name: Deploy Postman collection
+        env:
+          API_KEY: ${{ secrets.API_KEY }}
         run: node deployPostmanCollection.js

--- a/.github/workflows/deployPostmanCollection.yml
+++ b/.github/workflows/deployPostmanCollection.yml
@@ -13,17 +13,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js v14.x
+      - name: Use Node.js v16.x
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
           cache: 'npm'
 
-      - name: Install npm 8.3.0
-        run: npm install -g npm@8.3.0
+      - name: Install npm 8.5.0
+        run: npm install -g npm@8.5.0
 
       - name: Npm Install
-        run: npm i
+        run: npm ci
 
       - name: Build
         run: node deployPostmanCollection.js

--- a/config.js
+++ b/config.js
@@ -1,4 +1,4 @@
-require('dotenv').config()
+if (!process.env.API_KEY) require('dotenv').config()
 
 const apiKey = process.env.API_KEY
 


### PR DESCRIPTION
O erro estava acontecendo pois não existe .env no repositório e não deve existir, porém apesar de já estar configurado uma secret para este papel, ela não estava sendo considerada na action.

Ajustei o config.js para só ler o .env se a variável de ambiente não estiver definida, o que deve acontecer quando o processo for rodado manualmente, na automatização do actions ele substituiria a chave presente no secret pelo undefinded novamente.

Além das atualizações das versões do node e npm foi trocad o `npm i` pelo pelo `npm ci` que é indicado para ambientes automatizados.