### PR TITLE
Desabilitando filtros vazios nas paginações

### DIFF
--- a/asaasPostmanCollection.json
+++ b/asaasPostmanCollection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "f649c187-f9cd-439d-987b-4678ac4f76b6",
+		"_postman_id": "2adde211-d6c4-4853-a282-b180894bab2e",
 		"name": "API ASAAS v3",
 		"description": "Nós aqui do Asaas adoramos poupar tempo de todo mundo, por isso fizemos essa collection com todas as nossas APIs. 👍\n\n# Documentação\n\n  \nA documentação completa pode ser acessada [neste link.](https://asaasv3.docs.apiary.io/)\n\nAmbientes disponíveis:\n\n*   Local\n*   Sandbox\n*   Produção\n    \n\nNão esquece de consultar as variáveis da coleção.\n\n## Autenticação\n\nPara testar os exemplos aqui descritos é necessário ter uma conta no Asaas. Caso você ainda não tenha, basta [criar uma conta clicando aqui](https://www.asaas.com/onboarding/createAccount?utm_source=postman) ou [aqui para criar em nossa sandbox](https://sandbox.asaas.com/onboarding/createAccount).\n\nA autenticação é feita através do fornecimento da sua API Key. Ela deve ser transmitida em todas as requisições no header \\`access_token\\`. Caso a API Key seja inválida ou não seja informada, o Asaas retornará `HTTP 401`.  \nAs API Keys são distintas entre os ambientes de Sandbox e Produção, portanto lembre-se de alterá-la quando mudar a URL.  \nPara obter sua API Key [acesse a Aba Integração na área Minha Conta](https://www.asaas.com/config/index?tab=pushNotification).  \nNa collection sua API Key pode ser informada na área de ambientes.\n\n> ***Atenção***:  \n> Sua API Key carrega muitos privilégios, portanto certifique-se de mantê-la protegida. Não informe ela em atendimentos e nem a exponha no front-end da sua aplicação. Além disso, não é possível recuperá-la caso perdida, sendo necessário a geração de uma nova.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -369,7 +369,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/payments?customer=&billingType=&status=&subscription=&installment=&externalReference=&paymentDate=&anticipated=&paymentDate%5Bge%5D=&paymentDate%5Ble%5D=&dueDate%5Bge%5D=&dueDate%5Ble%5D=&offset=&limit=",
+							"raw": "{{domain}}/api/v3/payments",
 							"host": [
 								"{{domain}}"
 							],
@@ -381,59 +381,73 @@
 							"query": [
 								{
 									"key": "customer",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "billingType",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "status",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "subscription",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "installment",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "externalReference",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "paymentDate",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "anticipated",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "paymentDate%5Bge%5D",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "paymentDate%5Ble%5D",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "dueDate%5Bge%5D",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "dueDate%5Ble%5D",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -706,7 +720,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/installments?offset=&limit=",
+							"raw": "{{domain}}/api/v3/installments",
 							"host": [
 								"{{domain}}"
 							],
@@ -718,11 +732,13 @@
 							"query": [
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -854,7 +870,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/subscriptions?customer=&billingType=&offset=&limit=&includeDeleted=&externalReference=",
+							"raw": "{{domain}}/api/v3/subscriptions",
 							"host": [
 								"{{domain}}"
 							],
@@ -866,27 +882,33 @@
 							"query": [
 								{
 									"key": "customer",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "billingType",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "includeDeleted",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "externalReference",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -1017,7 +1039,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/subscriptions/{{id_da_assinatura}}/invoices?offset=&limit=&status=",
+							"raw": "{{domain}}/api/v3/subscriptions/{{id_da_assinatura}}/invoices",
 							"host": [
 								"{{domain}}"
 							],
@@ -1031,15 +1053,18 @@
 							"query": [
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "status",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -1260,7 +1285,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/paymentLinks?active=&includeDeleted=&name=&offset=&limit=",
+							"raw": "{{domain}}/api/v3/paymentLinks",
 							"host": [
 								"{{domain}}"
 							],
@@ -1272,23 +1297,28 @@
 							"query": [
 								{
 									"key": "active",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "includeDeleted",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "name",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -1637,7 +1667,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/transfers?dateCreated=&type=",
+							"raw": "{{domain}}/api/v3/transfers",
 							"host": [
 								"{{domain}}"
 							],
@@ -1649,11 +1679,13 @@
 							"query": [
 								{
 									"key": "dateCreated",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "type",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -1783,7 +1815,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/anticipations?payment=&installment=&status=&offset=&limit=",
+							"raw": "{{domain}}/api/v3/anticipations",
 							"host": [
 								"{{domain}}"
 							],
@@ -1795,23 +1827,28 @@
 							"query": [
 								{
 									"key": "payment",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "installment",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "status",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -1986,7 +2023,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/paymentDunnings?status=&type=&payment=&requestStartDate=&requestEndDate=&offset=&limit=",
+							"raw": "{{domain}}/api/v3/paymentDunnings",
 							"host": [
 								"{{domain}}"
 							],
@@ -1998,31 +2035,38 @@
 							"query": [
 								{
 									"key": "status",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "type",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "payment",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "requestStartDate",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "requestEndDate",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2041,7 +2085,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/paymentDunnings/{{id_da_recuperacao}}/history?offset=&limit=",
+							"raw": "{{domain}}/api/v3/paymentDunnings/{{id_da_recuperacao}}/history",
 							"host": [
 								"{{domain}}"
 							],
@@ -2055,11 +2099,13 @@
 							"query": [
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2078,7 +2124,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/paymentDunnings/{{id_da_recuperacao}}/partialPayments?offset=&limit=",
+							"raw": "{{domain}}/api/v3/paymentDunnings/{{id_da_recuperacao}}/partialPayments",
 							"host": [
 								"{{domain}}"
 							],
@@ -2092,11 +2138,13 @@
 							"query": [
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2115,7 +2163,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/paymentDunnings/paymentsAvailableForDunning?offset=&limit=",
+							"raw": "{{domain}}/api/v3/paymentDunnings/paymentsAvailableForDunning",
 							"host": [
 								"{{domain}}"
 							],
@@ -2128,11 +2176,13 @@
 							"query": [
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2305,7 +2355,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/bill?offset=&limit=",
+							"raw": "{{domain}}/api/v3/bill",
 							"host": [
 								"{{domain}}"
 							],
@@ -2317,11 +2367,13 @@
 							"query": [
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2427,7 +2479,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/creditBureauReport?startDate=&endDate=&offset=&limit=",
+							"raw": "{{domain}}/api/v3/creditBureauReport",
 							"host": [
 								"{{domain}}"
 							],
@@ -2439,19 +2491,23 @@
 							"query": [
 								{
 									"key": "startDate",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "endDate",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2475,7 +2531,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/financialTransactions?startDate=&finishDate=&limit=&offset=",
+							"raw": "{{domain}}/api/v3/financialTransactions",
 							"host": [
 								"{{domain}}"
 							],
@@ -2487,19 +2543,23 @@
 							"query": [
 								{
 									"key": "startDate",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "finishDate",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2811,7 +2871,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/invoices?effectiveDate%5Bge%5D=&effectiveDate%5Ble%5D=&payment=&installment=&status=&offset=&limit=",
+							"raw": "{{domain}}/api/v3/invoices",
 							"host": [
 								"{{domain}}"
 							],
@@ -2823,31 +2883,38 @@
 							"query": [
 								{
 									"key": "effectiveDate%5Bge%5D",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "effectiveDate%5Ble%5D",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "payment",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "installment",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "status",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -2920,7 +2987,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/invoices/municipalServices?description=",
+							"raw": "{{domain}}/api/v3/invoices/municipalServices",
 							"host": [
 								"{{domain}}"
 							],
@@ -2933,7 +3000,8 @@
 							"query": [
 								{
 									"key": "description",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -3143,7 +3211,7 @@
 						"method": "GET",
 						"header": [],
 						"url": {
-							"raw": "{{domain}}/api/v3/pix/transactions?offset=&limit=&status=&type=",
+							"raw": "{{domain}}/api/v3/pix/transactions",
 							"host": [
 								"{{domain}}"
 							],
@@ -3156,19 +3224,23 @@
 							"query": [
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "status",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "type",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}
@@ -3549,7 +3621,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{domain}}/api/v3/accounts?cpfCnpj=&name=&email=&walletId=&limit=&offset=",
+							"raw": "{{domain}}/api/v3/accounts",
 							"host": [
 								"{{domain}}"
 							],
@@ -3561,27 +3633,33 @@
 							"query": [
 								{
 									"key": "cpfCnpj",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "name",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "email",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "walletId",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "offset",
-									"value": ""
+									"value": "",
+									"disabled": true
 								}
 							]
 						}


### PR DESCRIPTION
## Descrição

A regra de paginações na API do asaas é: Quando o usuário informa o parametro na url, filtramos por ele.
Como todos os exemplos de paginação ja possuiam os filtros pré aplicados na url, quando o usuário fazia o GET alguns lugares estouravam na aplicação, por todos os filtros estarem vazios.

Aqui estarei so desabilitando os filtros, ficando para o usuário a opção de habilita-los e informar algo.

Exemplo na paginação feita no /pix/transactions informando o parametro type como vazio

````
2022-04-17 21:49:46,084 [Thread-6195] [dd.trace_id=0] [dd.span_id=0] ERROR [API] erro ao acessar a url /api/v3/pix/transactions - [314978640] - [OTHER]. Stacktrace follows:
java.lang.IllegalArgumentException: No enum constant com.asaas.pix.PixTransactionType.
	at java.lang.Enum.valueOf(Enum.java:238)
	at sun.reflect.GeneratedMethodAccessor1563.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:93)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:325)
	at groovy.lang.MetaClassImpl.invokeStaticMethod(MetaClassImpl.java:1472)
	at groovy.lang.ExpandoMetaClass.invokeStaticMethod(ExpandoMetaClass.java:1138)
	at org.codehaus.groovy.runtime.callsite.StaticMetaClassSite.callStatic(StaticMetaClassSite.java:65)
	at 
````

## Tarefa Jira

## PR no Asaas
