### PR TITLE
Concordar ou discordar com aditivo do termo de uso do Asaas para contratação para o serviço de antecipação

### DIFF
--- a/asaasPostmanCollection.json
+++ b/asaasPostmanCollection.json
@@ -2038,7 +2038,7 @@
 					"response": []
 				},
 				{
-					"name": "Concordar ou discordar do termo aditivo de antecipação",
+					"name": "Concordar ou discordar com Aditivo aos Termos de Uso do ASAAS para contratação do Serviço de Antecipação",
 					"request": {
 						"method": "POST",
 						"header": [

--- a/asaasPostmanCollection.json
+++ b/asaasPostmanCollection.json
@@ -2036,6 +2036,37 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "Concordar ou discordar do termo aditivo de antecipação",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"agreed\": true\r\n}"
+						},
+						"url": {
+							"raw": "{{domain}}/api/v3/anticipations/agreement/sign",
+							"host": [
+								"{{domain}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"anticipations",
+								"agreement",
+								"sign"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},


### PR DESCRIPTION
## Descrição
Documentando novo endpoint para concordar ou discordar com aditivo do termo de uso do Asaas para contratação para o serviço de antecipação.

## Tarefa Jira
[SKS-330](https://asaasdev.atlassian.net/browse/SKS-330)

## PR no Asaas
- https://github.com/asaasdev/asaas/pull/24609

[SKS-330]: https://asaasdev.atlassian.net/browse/SKS-330?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ