### PR TITLE
remove referência ao termo aditivo de antecipação

### DIFF
--- a/asaasPostmanCollection.json
+++ b/asaasPostmanCollection.json
@@ -2024,36 +2024,6 @@
 						}
 					},
 					"response": []
-				},
-				{
-					"name": "Concordar ou discordar com Aditivo aos Termos de Uso do ASAAS para contratação do Serviço de Antecipação",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\r\n  \"agreed\": true\r\n}"
-						},
-						"url": {
-							"raw": "{{domain}}/v3/anticipations/agreement/sign",
-							"host": [
-								"{{domain}}"
-							],
-							"path": [
-								"v3",
-								"anticipations",
-								"agreement",
-								"sign"
-							]
-						}
-					},
-					"response": []
 				}
 			]
 		},


### PR DESCRIPTION
## Descrição
- Atualmente o endpoint do termo aditivo de antecipação se encontra deprecado e retornando dados mockados enquanto aguardamos o envio de emails para os clientes que consomem o endpoint, já que não é mais necessário assinar o termo manualmente, uma vez que está inserido no termo geral do ASAAS. Portanto, estamos removendo também da collection do postman.

## Tarefa Jira
- [SKS-1353](https://asaasdev.atlassian.net/browse/SKS-1353?atlOrigin=eyJpIjoiNjc1ODcwZjI2NzM5NDIwOTk2Mzc0MmQyOTkzNDhkN2IiLCJwIjoiaiJ9)

## PR no Asaas
- [PR que depreciou o enum](https://github.com/asaasdev/api-docs/pull/21)

[SKS-1353]: https://asaasdev.atlassian.net/browse/SKS-1353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ